### PR TITLE
fix missing include

### DIFF
--- a/imports/Grefsen/iconprovider.cpp
+++ b/imports/Grefsen/iconprovider.cpp
@@ -1,6 +1,7 @@
 #include "iconprovider.h"
 #include <qt5xdg/XdgIcon>
 
+#include <QDebug>
 #include <QDir>
 #include <QDirIterator>
 


### PR DESCRIPTION
fixes `error: invalid use of incomplete type 'class QDebug'` when compiling with qt 5.7
